### PR TITLE
install.sh: name schemashears in the summary and uninstall one-liner

### DIFF
--- a/packaging/install/install.sh
+++ b/packaging/install/install.sh
@@ -226,11 +226,12 @@ print_success() {
   printf '  schemaquench --version\n'
   printf '  schematongs --version\n'
   printf '  datatongs --version\n'
+  printf '  schemashears --version\n'
   if ! target_on_path; then
     print_path_fix
   fi
-  printf '\nTo uninstall: rm -f %s/schemaquench %s/schematongs %s/datatongs %s/libicu*.so.*\n' \
-    "$TARGET" "$TARGET" "$TARGET" "$TARGET"
+  printf '\nTo uninstall: rm -f %s/schemaquench %s/schematongs %s/datatongs %s/schemashears %s/libicu*.so.*\n' \
+    "$TARGET" "$TARGET" "$TARGET" "$TARGET" "$TARGET"
 }
 
 main() {


### PR DESCRIPTION
`install.sh` has installed **four** tools since SchemaShears shipped — `TOOLS` lists it and the file header says four — but `print_success` only ever named three.

The version-check list is cosmetic. **The uninstall line is not:** anyone following the printed command removed three binaries and silently left `schemashears` behind, with nothing to tell them it existed.

```diff
   printf '  datatongs --version\n'
+  printf '  schemashears --version\n'
   if ! target_on_path; then
     print_path_fix
   fi
-  printf '\nTo uninstall: rm -f %s/schemaquench %s/schematongs %s/datatongs %s/libicu*.so.*\n' \
-    "$TARGET" "$TARGET" "$TARGET" "$TARGET"
+  printf '\nTo uninstall: rm -f %s/schemaquench %s/schematongs %s/datatongs %s/schemashears %s/libicu*.so.*\n' \
+    "$TARGET" "$TARGET" "$TARGET" "$TARGET" "$TARGET"
```

## Verification

Against the **published** v2.5.0 release in a clean `ubuntu:24.04` container:

- Summary now lists all four tools.
- The printed uninstall command takes the install from **7 files to 0**, nothing left behind.
- `shellcheck --shell=sh` clean.

## Why this is a PR and not a direct push

`install.sh` is installer-class: it's piped straight from the web by people who never read it, so it counts as code even though it lives beside docs. This isn't an urgent hotfix — the installer works fine — so it doesn't qualify for the hot-fix carve-out either.

Found while validating the v2.5.0 release. The same three-vs-four drift was in the runbook and pre-release checklist (validation steps were under-checking by one binary); those are internal docs and already corrected.